### PR TITLE
Fix typos and clean up code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # small_object_augmentation
- Implementation of augmentation for small object detection https://arxiv.org/pdf/1902.07296.pdf
+Implementation of augmentation for small object detection <https://arxiv.org/pdf/1902.07296.pdf>
 
-# refer
-> thanks to great work by:https://github.com/gmayday1997/SmallObjectAugmentation
+## Reference
+Thanks to the great work by: <https://github.com/gmayday1997/SmallObjectAugmentation>
 

--- a/aug.py
+++ b/aug.py
@@ -115,18 +115,18 @@ def img_paths2label_paths(img_paths):
     return [img_path.replace('.jpg', '.txt') for img_path in img_paths]
 
 
-def random_search(all_labels, croped_label, shape, n_paste=1, iou_thresh=0.2):
+def random_search(all_labels, cropped_label, shape, n_paste=1, iou_thresh=0.2):
     """
         搜索出一个框
 
     :param all_labels:
-    :param croped_label:
+    :param cropped_label:
     :param shape:
     :param n_paste:
     :param iou_thresh:
     :return:
     """
-    cls, (bbox_h, bbox_w) = croped_label
+    cls, (bbox_h, bbox_w) = cropped_label
     # TODO: 这里会产生一个bug，当bbox等于H-1或者W-1时，后续变换会越界
     center_search_space = sample_new_bbox_center(shape, bbox_h, bbox_w)
 
@@ -159,25 +159,25 @@ def random_search(all_labels, croped_label, shape, n_paste=1, iou_thresh=0.2):
 from xml_utils import read_label_xml, write_label_xml
 
 
-def paste_small_objects_to_single_img(img_path, label_path, croped_images, croped_dir, save_img_dir, save_anno_dir,
-                                                                        n_bboxes=6, prob=1.0, origin_rescale=False,
-                                                                        origin_rescaled_size=800, croped_rescale=False,
-                                                                        croped_rescale_size=150):
+def paste_small_objects_to_single_img(img_path, label_path, cropped_images, cropped_dir, save_img_dir, save_anno_dir,
+                                      n_bboxes=6, prob=1.0, origin_rescale=False,
+                                      origin_rescaled_size=800, cropped_rescale=False,
+                                      cropped_rescale_size=150):
     """
             按照一定的概率去paste
-    :param croped_rescale_size:
-    :param croped_rescale:
+    :param cropped_rescale_size:
+    :param cropped_rescale:
     :param origin_rescaled_size:
-    :param origin_rescale:          是否reseize原始尺寸，使得crop图像不至于太小
+    :param origin_rescale:          是否resize原始尺寸，使得crop图像不至于太小
     :param prob:
     :param save_anno_dir:
     :param save_img_dir:
-    :param croped_dir:
+    :param cropped_dir:
     :param img_path:
     :param label_path:
-    :param croped_images:
+    :param cropped_images:
     :param n_bboxes:
-    :type croped_images: dict
+    :type cropped_images: dict
     :return:
     """
     if random.randint(0, 1) > prob:
@@ -235,24 +235,24 @@ def paste_small_objects_to_single_img(img_path, label_path, croped_images, crope
     all_labels.extend(origin_labels)
 
     # 从待选的crop图像中选取n个填充到原图像中
-    n_croped_images = len(croped_images.keys())
-    list_croped_images = list(croped_images.keys())
-    tmp_idx = np.random.permutation(n_croped_images)
+    n_cropped_images = len(cropped_images.keys())
+    list_cropped_images = list(cropped_images.keys())
+    tmp_idx = np.random.permutation(n_cropped_images)
 
     # 往图像中插入图
     for i in range(n_bboxes):
         # 读取crop图像
-        croped_id = list_croped_images[tmp_idx[i]]
-        croped_img_path = os.path.join(croped_dir, croped_id + '.jpg')
-        croped_cls = croped_images.get(croped_id)
+        cropped_id = list_cropped_images[tmp_idx[i]]
+        cropped_img_path = os.path.join(cropped_dir, cropped_id + '.jpg')
+        cropped_cls = cropped_images.get(cropped_id)
 
-        roi = cv2_im_read(croped_img_path)
+        roi = cv2_im_read(cropped_img_path)
         _h, _w, _ = roi.shape
         # TODO: resize 小图像
-        if croped_rescale:
+        if cropped_rescale:
             # 足够小
             if max(_h, _w) < 80:
-                roi = cv2.resize(roi, (int(_w * (croped_rescale_size / _h)), croped_rescale_size),
+                roi = cv2.resize(roi, (int(_w * (cropped_rescale_size / _h)), cropped_rescale_size),
                                                                                         interpolation=cv2.INTER_CUBIC)
 
         # debug
@@ -260,10 +260,10 @@ def paste_small_objects_to_single_img(img_path, label_path, croped_images, crope
         # cv2.imshow('', roi)
         # cv2.waitKey(0)
 
-        croped_label = [croped_cls, roi.shape[:2]]
+        cropped_label = [cropped_cls, roi.shape[:2]]
 
         # searching for places
-        new_bboxes = random_search(all_labels, croped_label, origin_image.shape, n_paste=1, iou_thresh=0.2)
+        new_bboxes = random_search(all_labels, cropped_label, origin_image.shape, n_paste=1, iou_thresh=0.2)
 
         for new_label in new_bboxes:
             all_labels.append(new_label)

--- a/crop_hard_samples_from_image.py
+++ b/crop_hard_samples_from_image.py
@@ -80,7 +80,7 @@ for xml in tqdm(xml_files, desc='searching xml files'):
 
 # 2、写入文件
 with open('txt/hard_samples_3_cat.txt', 'w') as f:
-    for item in tqdm(needed_xmls, desc='wirte files'):
+    for item in tqdm(needed_xmls, desc='write files'):
         item_id = item.split('.xml')[0]
         f.write(item_id + '\n')
 

--- a/main_paste_by_every_hard_class.py
+++ b/main_paste_by_every_hard_class.py
@@ -29,7 +29,7 @@ PASTE_IMG_DIR = r'G:\比赛\华为垃圾目标检测分类\数据\trainval\VOC20
 PASTE_ANNO_DIR = r'G:\比赛\华为垃圾目标检测分类\数据\trainval\VOC2007\Augmentation\Annotations'
 
 # TODO: cv2不支持中文路径，这里可以check一下
-CROPED_IMG_DIR = r'G:\data\trainval\VOC2007\Crop_3_150x150'
+CROPPED_IMG_DIR = r'G:\data\trainval\VOC2007\Crop_3_150x150'
 
 MAX_WIDTH = 1000
 MAX_HEIGHT = 1000
@@ -88,18 +88,18 @@ def read_anno_for_size_cls(anno_path, related_classes):
 
     return (h, w), use_this_sample
 
-def get_all_croped_image_path(_hard_cls, croped_dir=CROPED_IMG_DIR):
+def get_all_cropped_image_paths(_hard_cls, cropped_dir=CROPPED_IMG_DIR):
     """
         获取crop图像的列表，返回dict
     :param _hard_cls:
     :param hard_cls:
-    :param croped_dir:
+    :param cropped_dir:
     :return:
     """
     result_dict = dict()
 
     # 文件格式: [cls]_[source]_[timestamp].jpg ---> 文件格式: [cls]_[source]_[timestamp]
-    img_file_names = [x.split('.jpg')[0] for x in os.listdir(croped_dir)]
+    img_file_names = [x.split('.jpg')[0] for x in os.listdir(cropped_dir)]
 
     for file_name in img_file_names:
         _cls = file_name.split('_')[0]
@@ -137,18 +137,22 @@ if __name__ == "__main__":
         source_ids = search_anno_dir(ANNO_DIR, related_classes=rlt_cls)
 
         # step 1 获取所有的crop下来的图像
-        croped_image_dict = get_all_croped_image_path(cls, CROPED_IMG_DIR)
+        cropped_image_dict = get_all_cropped_image_paths(cls, CROPPED_IMG_DIR)
 
         # 遍历每一个图像，并且在里面随机进行paste
-        for source_id in tqdm(source_ids, desc=f'hard class:{cls}, pasting croped images.'):
+        for source_id in tqdm(source_ids, desc=f'hard class:{cls}, pasting cropped images.'):
             source_img_path = os.path.join(IMG_DIR, source_id+'.jpg')
             source_anno_path = os.path.join(ANNO_DIR, source_id+'.xml')
 
             # step 2 随机从crop的图像中选取n个出来paste，个数取决于这个图像的分辨率, 将得到的图像保存的熬指定的位置
-            paste_small_objects_to_single_img(source_img_path, source_anno_path, croped_image_dict,
-                                                      croped_dir=CROPED_IMG_DIR,
-                                                      save_img_dir=PASTE_IMG_DIR,
-                                                      save_anno_dir=PASTE_ANNO_DIR,
-                                                      prob=0.3,
-                                                      origin_rescale=True,  # 对于原始图像resize
-                                                      croped_rescale=True)  # 对于crop的图像resize
+            paste_small_objects_to_single_img(
+                source_img_path,
+                source_anno_path,
+                cropped_image_dict,
+                cropped_dir=CROPPED_IMG_DIR,
+                save_img_dir=PASTE_IMG_DIR,
+                save_anno_dir=PASTE_ANNO_DIR,
+                prob=0.3,
+                origin_rescale=True,  # 对于原始图像resize
+                cropped_rescale=True
+            )  # 对于crop的图像resize

--- a/main_zx.py
+++ b/main_zx.py
@@ -34,7 +34,7 @@ PASTE_IMG_DIR = r'G:\比赛\华为垃圾目标检测分类\数据\trainval\VOC20
 PASTE_ANNO_DIR = r'G:\比赛\华为垃圾目标检测分类\数据\trainval\VOC2007\Augmentation\Annotations'
 
 # TODO: cv2不支持中文路径，这里可以check一下
-CROPED_IMG_DIR = r'G:\data\trainval\VOC2007\Crop_3_150x150'
+CROPPED_IMG_DIR = r'G:\data\trainval\VOC2007\Crop_3_150x150'
 
 MAX_WIDTH = 800
 MAX_HEIGHT = 800
@@ -79,16 +79,16 @@ def read_anno_for_size(anno_path):
 
     return h, w
 
-def get_all_croped_image_path(croped_dir=CROPED_IMG_DIR):
+def get_all_cropped_image_paths(cropped_dir=CROPPED_IMG_DIR):
     """
         获取crop图像的列表，返回dict
-    :param croped_dir:
+    :param cropped_dir:
     :return:
     """
     result_dict = dict()
 
     # 文件格式: [cls]_[source]_[timestamp].jpg ---> 文件格式: [cls]_[source]_[timestamp]
-    img_file_names = [x.split('.jpg')[0] for x in os.listdir(croped_dir)]
+    img_file_names = [x.split('.jpg')[0] for x in os.listdir(cropped_dir)]
 
     for file_name in img_file_names:
         cls = file_name.split('_')[0]
@@ -102,15 +102,16 @@ if __name__ == "__main__":
     print(source_ids)
 
     # step 1 获取所有的crop下来的图像
-    croped_image_dict = get_all_croped_image_path(CROPED_IMG_DIR)
+    cropped_image_dict = get_all_cropped_image_paths(CROPPED_IMG_DIR)
 
     # 遍历每一个图像，并且在里面随机进行paste
-    for source_id in tqdm(source_ids, desc='pasting croped images.'):
+    for source_id in tqdm(source_ids, desc='pasting cropped images.'):
         source_img_path = os.path.join(IMG_DIR, source_id+'.jpg')
         source_anno_path = os.path.join(ANNO_DIR, source_id+'.xml')
 
         # step 2 随机从crop的图像中选取n个出来paste，个数取决于这个图像的分辨率, 将得到的图像保存的熬指定的位置
-        paste_small_objects_to_single_img(source_img_path, source_anno_path, croped_image_dict,
-                                                  croped_dir=CROPED_IMG_DIR,
+        paste_small_objects_to_single_img(source_img_path, source_anno_path, cropped_image_dict,
+                                          cropped_dir=CROPPED_IMG_DIR,
                                                   save_img_dir=PASTE_IMG_DIR,
                                                   save_anno_dir=PASTE_ANNO_DIR)
+

--- a/xml_utils.py
+++ b/xml_utils.py
@@ -39,7 +39,7 @@ def read_label_xml(xml_label_path):
 
     return rs_labels
 
-def create_element_ndoe(doc, tag, value):
+def create_element_node(doc, tag, value):
     """
         添加xmlnode
     :param doc:
@@ -62,7 +62,7 @@ def create_child_node(doc, tag, value, parent_node):
     :param parent_node:
     :return:
     """
-    child_node = create_element_ndoe(doc, tag, value)
+    child_node = create_element_node(doc, tag, value)
     parent_node.appendChild(child_node)
 
 


### PR DESCRIPTION
## Summary
- fix typos in README and comments
- rename `create_element_ndoe` to `create_element_node`
- standardize `cropped` naming across code
- update scripts to use new naming

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68425772a62c83269c7d0a29f4bcd5d2